### PR TITLE
Wrap around an external program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ default: test
 fetch-dependencies:
 	go get gopkg.in/op/go-logging.v1
 	go get gopkg.in/yaml.v2
+	go get -t ./...
 
 unittest:
 	go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ default: test
 fetch-dependencies:
 	go get gopkg.in/op/go-logging.v1
 	go get gopkg.in/yaml.v2
-	go get -t ./...
 
 unittest:
 	go test -v ./...

--- a/lib/config.go
+++ b/lib/config.go
@@ -89,7 +89,9 @@ func (this *WormholeConfig) AvailableApps() string {
 
 func (this *WormholeConfig) translatePath(path string) string {
 	for from, to := range this.Mapping {
-		path = strings.Replace(path, from, to, 1)
+		if strings.Index(path, from) == 0 {
+			return filepath.FromSlash(strings.Replace(path, from, to, 1))
+		}
 	}
 
 	return filepath.FromSlash(path)

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/kiesel/wormhole-go/lib"
+	"../lib/"
 	"gopkg.in/op/go-logging.v1"
 )
 

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/kiesel/wormhole-go/lib/"
+	"github.com/kiesel/wormhole-go/lib"
 	"gopkg.in/op/go-logging.v1"
 )
 

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/kiesel/wormhole-go/lib"
@@ -95,7 +96,7 @@ func main() {
 	// Read config
 	readConfiguration()
 
-	// Start main
+	// Start server
 	log.Info("Wormhole %s server starting ...", Version())
 
 	l, err := net.Listen("tcp4", config.GetAddr())
@@ -103,9 +104,29 @@ func main() {
 		log.Fatal(err)
 	}
 
+	defer l.Close()
+	go listenOn(l)
+
+	// Start program
+	c := exec.Command("C:\\Windows\\System32\\bash.exe")
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	log.Info("Wormhole command %s starting ...", c)
+
+	if err := c.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := c.Wait(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func listenOn(l net.Listener) {
 	log.Info("Listening at " + l.Addr().String())
 
-	defer l.Close()
 	for {
 		// Wait for connection
 		conn, err := l.Accept()

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -114,6 +114,7 @@ func main() {
 		go listenOn(l)
 
 		c := exec.Command(args[0], args[1:len(args)]...)
+		log.Info("Wormhole command %s starting ...", c)
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
@@ -124,7 +125,6 @@ func main() {
 		c.Env = append(c.Env, fmt.Sprintf("WORMHOLE_PORT=%d", addr.Port))
 		c.Env = append(c.Env, fmt.Sprintf("WORMHOLE_IP=%s", addr.IP))
 
-		log.Info("Wormhole command %s starting ...", c)
 
 		if err := c.Start(); err != nil {
 			log.Fatal(err)

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"../lib/"
+	"github.com/kiesel/wormhole-go/lib/"
 	"gopkg.in/op/go-logging.v1"
 )
 

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -111,7 +111,7 @@ func main() {
 		go listenOn(l)
 
 		// Start program
-		c := exec.Command(args[0])
+		c := exec.Command(args[0], args[1:len(args)]...)
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -105,22 +105,28 @@ func main() {
 	}
 
 	defer l.Close()
-	go listenOn(l)
 
-	// Start program
-	c := exec.Command("C:\\Windows\\System32\\bash.exe")
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	args := flag.Args()
+	if len(args) > 0 {
+		go listenOn(l)
 
-	log.Info("Wormhole command %s starting ...", c)
+		// Start program
+		c := exec.Command(args[0])
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
 
-	if err := c.Start(); err != nil {
-		log.Fatal(err)
-	}
+		log.Info("Wormhole command %s starting ...", c)
 
-	if err := c.Wait(); err != nil {
-		log.Fatal(err)
+		if err := c.Start(); err != nil {
+			log.Fatal(err)
+		}
+
+		if err := c.Wait(); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		listenOn(l)
 	}
 }
 

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -117,6 +117,12 @@ func main() {
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
+		c.Env = os.Environ()
+
+		// Expose address and port via environment
+		addr := l.Addr().(*net.TCPAddr)
+		c.Env = append(c.Env, fmt.Sprintf("WORMHOLE_PORT=%d", addr.Port))
+		c.Env = append(c.Env, fmt.Sprintf("WORMHOLE_IP=%s", addr.IP))
 
 		log.Info("Wormhole command %s starting ...", c)
 

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -111,7 +111,7 @@ func main() {
 
 	args := flag.Args()
 	if len(args) == 0 {
-		select{}
+		select {}
 	} else {
 		if err := runCommand(args, injectVia, l.Addr().(*net.TCPAddr)); err != nil {
 			log.Fatal(err)

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -106,11 +106,13 @@ func main() {
 
 	defer l.Close()
 
+	// Start program if passed via command line, otherwise revert to old behavior
 	args := flag.Args()
-	if len(args) > 0 {
+	if len(args) == 0 {
+		listenOn(l)
+	} else {
 		go listenOn(l)
 
-		// Start program
 		c := exec.Command(args[0], args[1:len(args)]...)
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
@@ -125,8 +127,6 @@ func main() {
 		if err := c.Wait(); err != nil {
 			log.Fatal(err)
 		}
-	} else {
-		listenOn(l)
 	}
 }
 


### PR DESCRIPTION
## In a nutshell

Starts the server, runs the program and shuts down the server after this program has finished. Usecase:

``` sh
C:\> go run wormhole\wormhole.go C:\Windows\System32\bash.exe ~
# ...

thekid@SLATE ~
$  echo "invoke sublime README.md" | nc 127.0.0.1 5115 -w 1
```
## TODO
- [x] Pass command to run via command line
- [x] Bind any port (_using `listen: 127.0.0.1:0` in ~/.wormhole.yml_), export that as environment variable -> `WORMHOLE_PORT=62393` (& `WORMHOLE_IP=127.0.0.1`)
- [x] Make this work with Windows 10 bash, it does not inherit any environment variables!
- [x] ~~Add a bit of security: Create random token, pass that as environment variable~~ (_deferred for separate PR_)
## Other implementations

See https://github.com/xilun/cbwin - 
